### PR TITLE
Add snippet to display available timeslots

### DIFF
--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -129,6 +129,52 @@ $modx->log(modX::LOG_LEVEL_INFO,'Packaged in core, requirements validator, and m
 //    unset($settings,$setting,$attributes);
 //}
 
+/**
+ * Category
+ */
+$category= $modx->newObject('modCategory');
+$category->set('category','Commerce_Timeslots');
+$modx->log(modX::LOG_LEVEL_INFO,'Created category.');
+
+/**
+ * Snippets
+ */
+$snippetSource = include $sources['data'].'snippets.php';
+$snippets = [];
+foreach($snippetSource as $name => $options) {
+    $snippets[$name] = $modx->newObject('modSnippet');
+    $snippets[$name]->fromArray([
+        'name' => $name,
+        'description' => $options['description'],
+        'snippet' => getSnippetContent($sources['snippets'].$options['file']),
+    ],'',true,true);
+}
+$category->addMany($snippets);
+unset($snippets);
+$modx->log(modX::LOG_LEVEL_INFO,'Packaged in snippets.');
+
+$attr = [
+    xPDOTransport::UNIQUE_KEY => 'category',
+    xPDOTransport::PRESERVE_KEYS => false,
+    xPDOTransport::UPDATE_OBJECT => true,
+    xPDOTransport::RELATED_OBJECTS => true,
+    xPDOTransport::RELATED_OBJECT_ATTRIBUTES => [
+        'Chunks' => [
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UPDATE_OBJECT => true,
+            xPDOTransport::UNIQUE_KEY => 'name',
+        ],
+        'Snippets' => [
+            xPDOTransport::PRESERVE_KEYS => false,
+            xPDOTransport::UPDATE_OBJECT => true,
+            xPDOTransport::UNIQUE_KEY => 'name',
+        ],
+    ]
+];
+
+$vehicle = $builder->createVehicle($category,$attr);
+$builder->putVehicle($vehicle);
+
 /* now pack in the license file, readme and setup options */
 $builder->setPackageAttributes([
     'license' => file_get_contents($sources['docs'] . 'license.txt'),

--- a/_build/build.transport.php
+++ b/_build/build.transport.php
@@ -23,8 +23,8 @@ if (!defined('MOREPROVIDER_BUILD')) {
     /* define version */
     define('PKG_NAME', 'Commerce_TimeSlots');
     define('PKG_NAMESPACE', 'commerce_timeslots');
-    define('PKG_VERSION', '1.0.0');
-    define('PKG_RELEASE', 'rc2');
+    define('PKG_VERSION', '1.1.0');
+    define('PKG_RELEASE', 'rc1');
 
     /* load modx */
     require_once dirname(__DIR__) . '/config.core.php';
@@ -38,7 +38,7 @@ if (!defined('MOREPROVIDER_BUILD')) {
 else {
     $targetDirectory = MOREPROVIDER_BUILD_TARGET;
 }
-
+echo '<pre>';
 $root = dirname(__DIR__).'/';
 $sources = [
     'root' => $root,
@@ -144,7 +144,7 @@ $snippets = [];
 foreach($snippetSource as $name => $options) {
     $snippets[$name] = $modx->newObject('modSnippet');
     $snippets[$name]->fromArray([
-        'name' => $name,
+        'name' => $options['name'],
         'description' => $options['description'],
         'snippet' => getSnippetContent($sources['snippets'].$options['file']),
     ],'',true,true);

--- a/_build/data/snippets.php
+++ b/_build/data/snippets.php
@@ -1,0 +1,7 @@
+<?php
+return [
+    'Commerce_Timeslots' => [
+        'description'  =>  '',
+        'file'  =>  'get_timeslots.snippet.php',
+    ]
+];

--- a/_build/data/snippets.php
+++ b/_build/data/snippets.php
@@ -1,7 +1,8 @@
 <?php
 return [
     'Commerce_Timeslots' => [
-        'description'  =>  '',
-        'file'  =>  'get_timeslots.snippet.php',
+        'name'          =>  'commerce.get_timeslots',
+        'description'   =>  '',
+        'file'          =>  'get_timeslots.snippet.php',
     ]
 ];

--- a/_build/elements/snippets/get_timeslots.snippet.php
+++ b/_build/elements/snippets/get_timeslots.snippet.php
@@ -5,17 +5,20 @@
  * Add this snippet to any MODX template to either display a grid of available timeslots, or display a notice:
  * "Order by {date|time} to pick up at {timeslot}".
  *
- * This snippet currently has two parameters that can be used.
+ * This snippet currently has three parameters that can be used.
  *
  * - &shippingMethod: Add a shipping id here to only display timeslots for that shipping method. If not used, timeslots for all
  *          shipping methods will be displayed.
  *
  * - &tpl: Specify the twig template file to use. Default: timeslots/frontend/snippet_grid.twig
  *
+ * - &toPlaceholder: To have the output display via placeholder instead, specify the placeholder name you would like to use.
+ *
  * Example usage:
  * [[!commerce.get_timeslots?
  *     &shippingMethod=`4`
  *     &tpl=`timeslots/frontend/snippet_order_by.twig`
+ *     &toPlaceholder=`timeslots_grid`
  * ]]
  *
  *
@@ -38,4 +41,12 @@ if ($timeslots->commerce->isDisabled()) {
     return $timeslots->commerce->adapter->lexicon('commerce.mode.disabled.message');
 }
 
-return $timeslots->getTimeslots($scriptProperties);
+$output = $timeslots->getTimeslots($scriptProperties);
+
+if(isset($scriptProperties['toPlaceholder']) && !empty($scriptProperties['toPlaceholder'])) {
+    // Set output to placeholder using the value as the placeholder name
+    $modx->setPlaceholder($scriptProperties['toPlaceholder'],$output);
+    return '';
+}
+
+return $output;

--- a/_build/elements/snippets/get_timeslots.snippet.php
+++ b/_build/elements/snippets/get_timeslots.snippet.php
@@ -8,18 +8,15 @@
 $path = $modx->getOption('commerce_timeslots.core_path', null, MODX_CORE_PATH . 'components/commerce_timeslots/') . 'model/commerce_timeslots/';
 $params = ['mode' => $modx->getOption('commerce.mode')];
 
-/** @var Commerce_Timeslots|null $commerceTimeslots */
-$commerceTimeslots = $modx->getService('commerce_timeslots', 'Commerce_Timeslots', $path, $params);
-if (!($commerceTimeslots instanceof Commerce_Timeslots)) {
+/** @var Commerce_Timeslots|null $timeslots */
+$timeslots = $modx->getService('commerce_timeslots', 'Commerce_Timeslots', $path, $params);
+if (!($timeslots instanceof Commerce_Timeslots)) {
     $modx->log(modX::LOG_LEVEL_ERROR, 'Could not load Commerce_Timeslots service in commerce_timeslots.get_timeslots snippet.');
     return 'Could not load Commerce_Timeslots. Please try again later.';
 }
 
-if ($commerceTimeslots->commerce->isDisabled()) {
-    return $commerceTimeslots->commerce->adapter->lexicon('commerce.mode.disabled.message');
+if ($timeslots->commerce->isDisabled()) {
+    return $timeslots->commerce->adapter->lexicon('commerce.mode.disabled.message');
 }
 
-// TODO: have an option to display order by instead of grid
-$grid = $commerceTimeslots->getTimeslotsGrid();
-
-return $grid;
+return $timeslots->getTimeslots($scriptProperties);

--- a/_build/elements/snippets/get_timeslots.snippet.php
+++ b/_build/elements/snippets/get_timeslots.snippet.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * @var modX $modx
+ * @var array $scriptProperties
+ */
+
+// Instantiate the Commerce_Timeslots class
+$path = $modx->getOption('commerce_timeslots.core_path', null, MODX_CORE_PATH . 'components/commerce_timeslots/') . 'model/commerce_timeslots/';
+$params = ['mode' => $modx->getOption('commerce.mode')];
+
+/** @var Commerce_Timeslots|null $commerceTimeslots */
+$commerceTimeslots = $modx->getService('commerce_timeslots', 'Commerce_Timeslots', $path, $params);
+if (!($commerceTimeslots instanceof Commerce_Timeslots)) {
+    $modx->log(modX::LOG_LEVEL_ERROR, 'Could not load Commerce_Timeslots service in commerce_timeslots.get_timeslots snippet.');
+    return 'Could not load Commerce_Timeslots. Please try again later.';
+}
+
+if ($commerceTimeslots->commerce->isDisabled()) {
+    return $commerceTimeslots->commerce->adapter->lexicon('commerce.mode.disabled.message');
+}
+
+// TODO: have an option to display order by instead of grid
+$grid = $commerceTimeslots->getTimeslotsGrid();
+
+return $grid;

--- a/_build/elements/snippets/get_timeslots.snippet.php
+++ b/_build/elements/snippets/get_timeslots.snippet.php
@@ -1,5 +1,25 @@
 <?php
 /**
+ * commerce.get_timeslots
+ *
+ * Add this snippet to any MODX template to either display a grid of available timeslots, or display a notice:
+ * "Order by {date|time} to pick up at {timeslot}".
+ *
+ * This snippet currently has two parameters that can be used.
+ *
+ * - &shipId: Add a shipping id here to only display timeslots for that shipping method. If not used, timeslots for all
+ *          shipping methods will be displayed.
+ *
+ * - &orderBy: Set this value to 1 and the output of the snippet will be the "Order by" notice. Don't set it to
+ *          output the grid instead.
+ *
+ * Example usage:
+ * [[!commerce.get_timeslots?
+ *     &shipId=`4`
+ *     &orderBy=`1`
+ * ]]
+ *
+ *
  * @var modX $modx
  * @var array $scriptProperties
  */

--- a/_build/elements/snippets/get_timeslots.snippet.php
+++ b/_build/elements/snippets/get_timeslots.snippet.php
@@ -18,7 +18,7 @@
  * [[!commerce.get_timeslots?
  *     &shippingMethod=`4`
  *     &tpl=`timeslots/frontend/snippet_order_by.twig`
- *     &toPlaceholder=`timeslots_grid`
+ *     &toPlaceholder=`timeslots_output`
  * ]]
  *
  *

--- a/_build/elements/snippets/get_timeslots.snippet.php
+++ b/_build/elements/snippets/get_timeslots.snippet.php
@@ -7,16 +7,15 @@
  *
  * This snippet currently has two parameters that can be used.
  *
- * - &shipId: Add a shipping id here to only display timeslots for that shipping method. If not used, timeslots for all
+ * - &shippingMethod: Add a shipping id here to only display timeslots for that shipping method. If not used, timeslots for all
  *          shipping methods will be displayed.
  *
- * - &orderBy: Set this value to 1 and the output of the snippet will be the "Order by" notice. Don't set it to
- *          output the grid instead.
+ * - &tpl: Specify the twig template file to use. Default: timeslots/frontend/snippet_grid.twig
  *
  * Example usage:
  * [[!commerce.get_timeslots?
- *     &shipId=`4`
- *     &orderBy=`1`
+ *     &shippingMethod=`4`
+ *     &tpl=`timeslots/frontend/snippet_order_by.twig`
  * ]]
  *
  *

--- a/core/components/commerce_timeslots/docs/changelog.txt
+++ b/core/components/commerce_timeslots/docs/changelog.txt
@@ -1,8 +1,9 @@
-TimeSlots for Commerce 1.0.1-pl
+TimeSlots for Commerce 1.1.0-pl
 ----------------------------------
 Released on 2021-
 
 - Add missing translation files
+- Add snippet to render available timeslots as either grid or "order by".
 
 TimeSlots for Commerce 1.0.0-pl
 ----------------------------------

--- a/core/components/commerce_timeslots/lexicon/en/default.inc.php
+++ b/core/components/commerce_timeslots/lexicon/en/default.inc.php
@@ -59,3 +59,6 @@ $_lang['commerce.ReserveTimeSlotStatusChangeAction'] = 'Reserve Time Slot';
 
 $_lang['commerce_timeslots.orders'] = 'Received Orders for ';
 
+// Snippet
+$_lang['commerce_timeslots.snippet.order_by_to_pick_up'] = 'Order by [[+order_by]] to pick up at [[+from]] &ndash; [[+until]]';
+

--- a/core/components/commerce_timeslots/model/commerce_timeslots/commerce_timeslots.class.php
+++ b/core/components/commerce_timeslots/model/commerce_timeslots/commerce_timeslots.class.php
@@ -1,0 +1,128 @@
+<?php
+/**
+ * Commerce_Timeslots
+ *
+ * Copyright 2021 by Mark Hamstra <mark@modmore.com>
+ *
+ * This file is part of Commerce_Timeslots, developed for modmore.
+ *
+ * It is built to be used with the MODX Revolution CMS.
+ *
+ * @category commerce
+ * @package commerce_timeslots
+ * @author Mark Hamstra <mark@modmore.com>
+ * @license See core/components/commerce/docs/license.txt
+ * @link https://www.modmore.com/commerce/
+ */
+class Commerce_Timeslots {
+
+    public $modx = null;
+    public $commerce = null;
+    public $adapter = null;
+    public $namespace = 'commerce_timeslots';
+    public $cache = null;
+    public array $options = [];
+
+    private array $_available_options = [];
+
+
+    public function __construct(modX &$modx, array $options = []) {
+        $this->modx =& $modx;
+        $this->namespace = $this->getOption('namespace', $options, 'commerce_timeslots');
+
+        $corePath = $this->getOption('core_path', $options, $this->modx->getOption('core_path', null, MODX_CORE_PATH) . 'components/commerce_timeslots/');
+        $assetsPath = $this->getOption('assets_path', $options, $this->modx->getOption('assets_path', null, MODX_ASSETS_PATH) . 'components/commerce_timeslots/');
+        $assetsUrl = $this->getOption('assets_url', $options, $this->modx->getOption('assets_url', null, MODX_ASSETS_URL) . 'components/commerce_timeslots/');
+
+        $this->options = array_merge([
+            'namespace' => $this->namespace,
+            'corePath' => $corePath,
+            'modelPath' => $corePath . 'model/',
+            'chunksPath' => $corePath . 'elements/chunks/',
+            'snippetsPath' => $corePath . 'elements/snippets/',
+            'templatesPath' => $corePath . 'templates/',
+            'assetsPath' => $assetsPath,
+            'assetsUrl' => $assetsUrl,
+            'jsUrl' => $assetsUrl . 'js/',
+            'cssUrl' => $assetsUrl . 'css/',
+            'connectorUrl' => $assetsUrl . 'connector.php'
+        ], $options);
+
+        // Load the Commerce service
+        $commercePath = $modx->getOption('commerce.core_path', null, MODX_CORE_PATH . 'components/commerce/');
+        $this->commerce = $this->modx->getService('commerce','Commerce',$commercePath . 'model/commerce/',$options);
+        if (!($this->commerce instanceof \Commerce)) $this->modx->log(modX::LOG_LEVEL_ERROR,'Couldn\'t load Commerce service!');
+
+        $this->adapter = $this->commerce->adapter;
+        $this->adapter->loadLexicon('commerce:default');
+
+        $this->adapter->loadPackage('commerce_timeslots', $this->getOption('modelPath'));
+        $this->adapter->loadLexicon('commerce_timeslots:default');
+    }
+
+    /**
+     * Renders a grid with all available timeslots for each shipping method
+     * @return string
+     */
+    public function getTimeslotsGrid() {
+        $shippingMethods = $this->getShippingMethods();
+        if(empty($shippingMethods)) return '';
+
+        $output = '';
+        foreach($shippingMethods as $shippingMethod) {
+            if(!$shippingMethod instanceof TimeSlotsShippingMethod) continue;
+
+            $options = $shippingMethod->getAvailableSlots();
+
+            $output .= $this->commerce->view()->render('timeslots/frontend/snippet_grid.twig', [
+                'method' => $shippingMethod->toArray(),
+                'options' => $options,
+            ]);
+        }
+        return $output;
+    }
+
+    /**
+     * Retrieves an array of TimeslotsShippingMethods
+     * @return array
+     */
+    public function getShippingMethods() {
+        $c = $this->adapter->newQuery(TimeSlotsShippingMethod::class);
+
+        $where = [];
+        if ($this->commerce->isTestMode()) {
+            $where['enabled_in_test'] = true;
+        } else {
+            $where['enabled_in_live'] = true;
+        }
+        $where['class_key'] = TimeSlotsShippingMethod::class;
+        $c->where($where);
+
+        return $this->adapter->getIterator(TimeSlotsShippingMethod::class,$c);
+    }
+
+
+    /**
+     * Get a local configuration option or a namespaced system setting by key.
+     *
+     * @param string $key The option key to search for.
+     * @param array $options An array of options that override local options.
+     * @param mixed $default The default value returned if the option is not found locally or as a
+     * namespaced system setting; by default this value is null.
+     * @return mixed The option value or the default value specified.
+     */
+    public function getOption($key, $options = [], $default = null) {
+        $option = $default;
+        if (!empty($key) && is_string($key)) {
+            if ($options != null && array_key_exists($key, $options)) {
+                $option = $options[$key];
+            } elseif (array_key_exists($key, $this->options)) {
+                $option = $this->options[$key];
+            } elseif (array_key_exists("{$this->namespace}.{$key}", $this->modx->config)) {
+                $option = $this->modx->getOption("{$this->namespace}.{$key}");
+            }
+        }
+        return $option;
+    }
+
+}

--- a/core/components/commerce_timeslots/model/commerce_timeslots/commerce_timeslots.class.php
+++ b/core/components/commerce_timeslots/model/commerce_timeslots/commerce_timeslots.class.php
@@ -65,15 +65,15 @@ class Commerce_Timeslots {
     {
         // Check if a custom template was provided - grid template is used by default
         $tpl = $params['tpl'];
-        if(!$tpl) {
+        if (!$tpl) {
             $tpl = 'timeslots/frontend/snippet_grid.twig';
         }
 
         // Check if a shipping method id was specified ( 0 returns all )
-        $shippingMethodId = $params['shippingMethod'] ?? 0;
+        $shippingMethodId = (int) $params['shippingMethod'] ?? 0;
 
         $shippingMethods = $this->getShippingMethods($shippingMethodId);
-        if(empty($shippingMethods)) return '';
+        if (empty($shippingMethods)) return '';
 
         return $this->render($shippingMethods, $tpl);
     }
@@ -87,7 +87,7 @@ class Commerce_Timeslots {
     {
         $output = '';
         foreach($shippingMethods as $shippingMethod) {
-            if(!$shippingMethod instanceof TimeSlotsShippingMethod) continue;
+            if (!$shippingMethod instanceof TimeSlotsShippingMethod) continue;
 
             $options = $shippingMethod->getAvailableSlots();
 
@@ -115,7 +115,7 @@ class Commerce_Timeslots {
             $where['enabled_in_live:='] = true;
         }
         $where['AND:class_key:='] = TimeSlotsShippingMethod::class;
-        if($id > 0) {
+        if ($id > 0) {
             $where['AND:`id`:='] = $id;
         }
         $c->where($where);

--- a/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
+++ b/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
@@ -113,7 +113,7 @@ class TimeSlotsShippingMethod extends comShippingMethod
         return parent::setShippingInformation($order, $shipment, $data);
     }
 
-    private function getAvailableSlots(): array
+    public function getAvailableSlots(): array
     {
         if (!empty($this->_available_options)) {
             return $this->_available_options;

--- a/core/components/commerce_timeslots/templates/timeslots/frontend/snippet_grid.twig
+++ b/core/components/commerce_timeslots/templates/timeslots/frontend/snippet_grid.twig
@@ -1,0 +1,61 @@
+<div class="timeslots_container">
+    <h3 title="{{ method.name }}">{{ method.name }}</h3>
+    {# The filter here makes sure only dates that have at least one available are shown.
+        If desired, you could remove the filter(..) and show availability differently
+    #}
+{% for date, dateInfo in options|filter(v => v.available_slots > 0) %}
+    <div>
+        <div>
+            <span style="background:#f1f1f1; border-radius:5px; padding:3px 6px;">
+                {{ lex('commerce_timeslots.num_available_slots', { num: dateInfo.available_slots }) }}
+            </span>
+            &nbsp;
+            <span class="c-date">
+                {{ dateInfo.locale_day|default('unknown day') }} {{ dateInfo.locale_date_preferred }}
+            </span>
+        </div>
+
+        <div class="c-timeslots">
+            <ul style="max-width: 300px;">
+                {% if not dateInfo.locale_day %}
+                    {{ dump(date, dateInfo) }}
+                {% endif %}
+
+                {% for slot in dateInfo.slots|filter(v => v.available) %}
+                    <li class="c-timeslot" style="display:flex; justify-content: space-between; padding-bottom: 8px;">
+                        <span class="c-time">
+                            {{ slot.time_from|date('H:i') }}&ndash;{{ slot.time_until|date('H:i') }} {{ dateInfo.locale_date_tz }}
+
+                            {# If you'd like to show all slots, even those that are not available anymore,
+                                you could do something like this to give those slots a label after removing
+                                the |filter(..) on the for loop at line 29
+
+                                {% if not slot.available %}
+                                    {{ lex('commerce_timeslots.slot_unavailable') }}
+                                {% endif %}
+                            #}
+                        </span>
+                        {% if (slot.price + method.price) != 0 %}
+                            <span style="background:#f1f1f1; border-radius:5px; padding:0 3px;">
+                                {{ (method.price + slot.price)|format_currency }}
+                            </span>
+                        {% endif %}
+
+                    </li>
+                {% endfor %}
+            </ul>
+        </div>
+
+    </div>
+{% else %}
+    <div>
+        <div class="c-timeslots-error">
+            {{ lex('commerce_timeslots.no_options_available') }}
+        </div>
+    </div>
+{% endfor %}
+
+</div>
+
+{#{{ dump(shipment) }}#}
+{#{{ dump(options['2021-02-05']) }}#}

--- a/core/components/commerce_timeslots/templates/timeslots/frontend/snippet_grid.twig
+++ b/core/components/commerce_timeslots/templates/timeslots/frontend/snippet_grid.twig
@@ -1,4 +1,4 @@
-<div class="timeslots_container">
+<div class="c-timeslots-container">
     <h3 title="{{ method.name }}">{{ method.name }}</h3>
     {# The filter here makes sure only dates that have at least one available are shown.
         If desired, you could remove the filter(..) and show availability differently
@@ -57,5 +57,4 @@
 
 </div>
 
-{#{{ dump(shipment) }}#}
 {#{{ dump(options['2021-02-05']) }}#}

--- a/core/components/commerce_timeslots/templates/timeslots/frontend/snippet_order_by.twig
+++ b/core/components/commerce_timeslots/templates/timeslots/frontend/snippet_order_by.twig
@@ -1,0 +1,12 @@
+<div>
+    {{ method.name }}
+    <p>
+        {{ lex('commerce_timeslots.snippet.order_by_to_pick_up',{
+                order_by: options|first.slots|first.closes_after_formatted,
+                from: options|first.slots|first.time_from_formatted,
+                until: options|first.slots|first.time_until_formatted
+            })
+        }}
+    </p>
+</div>
+{# {{ dump(options|first) }} #}


### PR DESCRIPTION
This PR adds the snippet `commerce.get_timeslots`.

Add the snippet to any MODX template to display a grid of all available timeslots, or set the `&tpl` parameter to render any format desired.
An example `timeslots/frontend/snippet_order_by.twig` template is also included as an example.

