### PR TITLE
Select date via the slot id instead of relying on submitted date string

### DIFF
--- a/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
+++ b/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
@@ -67,13 +67,18 @@ class TimeSlotsShippingMethod extends comShippingMethod
             ? $firstAvailableDate['slots'] : [];
         $autoSelected = false;
 
-        // Check for a submitted date
-        if (array_key_exists('date', $data) && array_key_exists($data['date'], $options)) {
-            $selectedDate = $data['date'];
-            $selectedDateInfo = $options[$selectedDate];
-            $selectedDateSlots = $options[$selectedDate]['slots'];
-            $shipment->setProperty('timeslots_date', $selectedDate);
-            $shipment->unsetProperty('timeslots_slot');
+        // Set the date via submitted slot id
+        if (array_key_exists('slot', $data)) {
+            foreach($datesWithAvailability as $k => $date) {
+                if(isset($date['slots'][$data['slot']])) {
+                    $selectedDate = $k; // Date string is the array key
+                    $selectedDateInfo = $options[$selectedDate];
+                    $selectedDateSlots = $options[$selectedDate]['slots'];
+                    $shipment->setProperty('timeslots_date', $selectedDate);
+                    $shipment->unsetProperty('timeslots_slot');
+                    break;
+                }
+            }
         }
 
         // Check for a submitted slot on said day

--- a/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
+++ b/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
@@ -67,10 +67,18 @@ class TimeSlotsShippingMethod extends comShippingMethod
             ? $firstAvailableDate['slots'] : [];
         $autoSelected = false;
 
-        // Set the date via submitted slot id
-        if (array_key_exists('slot', $data)) {
-            foreach($datesWithAvailability as $k => $date) {
-                if(isset($date['slots'][$data['slot']])) {
+        // Check for a submitted date
+        if (array_key_exists('date', $data) && array_key_exists($data['date'], $options)) {
+            $selectedDate = $data['date'];
+            $selectedDateInfo = $options[$selectedDate];
+            $selectedDateSlots = $options[$selectedDate]['slots'];
+            $shipment->setProperty('timeslots_date', $selectedDate);
+            $shipment->unsetProperty('timeslots_slot');
+        }
+        // Set the date via submitted slot id if no date was provided by the template
+        else if (array_key_exists('slot', $data)) {
+            foreach ($datesWithAvailability as $k => $date) {
+                if (isset($date['slots'][$data['slot']])) {
                     $selectedDate = $k; // Date string is the array key
                     $selectedDateInfo = $options[$selectedDate];
                     $selectedDateSlots = $options[$selectedDate]['slots'];


### PR DESCRIPTION
This commit selects the correct date via the submitted slot id instead of the submitted date.

One thing I've noticed by making this change is that it means if a date is selected without a slot on that day being selected, it will assume nothing has been selected and revert to the first available date/timeslot.

@Mark-H what is your preferred behaviour for this? (I'm undecided so far...)
If a date is selected without a timeslot, should it select the first timeslot on that particular day, 
OR should it require a timeslot be selected no matter what and show some kind of a validation notice to the customer?

Resolves #7 
