### PR TITLE
Add a composite shipping method to allow more advanced price and availability calculations

### DIFF
--- a/core/components/commerce_timeslots/lexicon/en/default.inc.php
+++ b/core/components/commerce_timeslots/lexicon/en/default.inc.php
@@ -53,6 +53,8 @@ $_lang['commerce_timeslots.reservations_available'] = 'reservations available';
 $_lang['commerce_timeslots.reservations_placed'] = 'slots booked';
 $_lang['commerce_timeslots.no_date_slots'] = 'No slots defined, date not available for customers.';
 $_lang['commerce_timeslots.different_schedule'] = 'This slot is not part of the schedule selected for the current date. It may have been manually added or was left over after replacing the schedule.';
+$_lang['commerce_timeslots.composite_method'] = 'Composite Method';
+$_lang['commerce_timeslots.composite_method.desc'] = 'Optionally, you can configure a composite shipping method that will determine the <b>price and availability</b> of this shipping option. That means that the selected shipping method type will use its own rules to set the base price. <b>Individual time slots can still add an extra fee to a specific time slot</b>. Save the shipping method to see the configuration for the chosen composite method.';
 
 // Shipping method / frontend
 $_lang['commerce_timeslots.max_days_visible'] = 'Maximum days visible';

--- a/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
+++ b/core/components/commerce_timeslots/model/commerce_timeslots/timeslotsshippingmethod.class.php
@@ -226,6 +226,8 @@ class TimeSlotsShippingMethod extends comShippingMethod
     {
         if ($comp = $this->getCompositeMethod()) {
             $price = $comp->getPriceForShipment($shipment);
+            $this->setProperties(array_merge($this->getProperties(), $comp->getProperties()));
+            $this->save();
         }
         else {
             $price = parent::getPriceForShipment($shipment);
@@ -245,7 +247,10 @@ class TimeSlotsShippingMethod extends comShippingMethod
             return false;
         }
         if ($comp = $this->getCompositeMethod()) {
-            return $comp->isAvailableForShipment($shipment);
+            $isAvailable = $comp->isAvailableForShipment($shipment);
+            $this->setProperties(array_merge($this->getProperties(), $comp->getProperties()));
+            $this->save();
+            return $isAvailable;
         }
         return true;
     }
@@ -262,6 +267,7 @@ class TimeSlotsShippingMethod extends comShippingMethod
             return null;
         }
         $comp->fromArray($this->toArray());
+        $comp->setProperty('composite_id', $this->get('id'));
 
         return $comp;
     }


### PR DESCRIPTION
Basically, outsource the price and advanced availability options to another shipping method. Like the Weight, Country, or Google Routes shipping methods. 

The price overrides the regular base price on the shipping method, so the per-slot price can still add a "surcharge" to specific high-value slots.  